### PR TITLE
Create role

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2016 Juwai
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Example Playbook
 License
 -------
 
-MIT / BSD
+MIT
 
 Author Information
 ------------------

--- a/README.md
+++ b/README.md
@@ -1,3 +1,88 @@
 Ansible Role: Filebeat
 =========
 
+Install Filebeat on CentOS servers.
+
+Requirements
+------------
+
+Written in Ansible 1.9.*
+
+Role Variables
+--------------
+
+Available variables are listed below, along with default values (see `defaults/main.yml`):
+
+### supervisord_config_dir
+
+Directory where supervisord reads configuration files.
+
+Default is `/etc/supervisor.d`.
+
+### filebeat_supervisor_enabled
+
+Install filebeat in supervisor or not.
+
+Default is true.
+
+### filebeat_version
+
+Filebeat version.
+
+Default is `1.0.1`.
+
+### filebeat_rpm_url
+
+URL where to download filebeat.
+
+Default is `https://download.elastic.co/beats/filebeat/filebeat-1.0.1-x86_64.rpm`.
+
+### filebeat_config_dir
+
+Directory for filebeat configuration file.
+
+Default is `/etc/filebeat`.
+
+### filebeat_log_dir
+
+Directory for filebeat log files.
+
+Default is `/var/log/filebeat`.
+
+### filebeat_group
+
+Group for filebeat user.
+
+Default is `filebeat`.
+
+### filebeat_user
+
+Filebeat user.
+
+Default is `filebeat`.
+
+### filebeat_config
+
+Filebeat configuration. Contents are copied as YAML directly to configuration file.
+
+Dependencies
+------------
+
++ juwai.supervisor, when filebeat_supervisor_enabled
+
+Example Playbook
+----------------
+
+    - hosts: servers
+      roles:
+         - juwai.filebeat
+
+License
+-------
+
+MIT / BSD
+
+Author Information
+------------------
+
+This role was created in 2016 by [Juwai Limited](http://www.juwai.com).

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,0 +1,28 @@
+---
+# defaults file for filebeat
+
+supervisord_config_dir: /etc/supervisor.d
+filebeat_supervisor_enabled: true
+
+filebeat_version: 1.0.1
+filebeat_rpm_url: https://download.elastic.co/beats/filebeat/filebeat-{{filebeat_version}}-x86_64.rpm
+filebeat_config_dir: /etc/filebeat
+filebeat_log_dir: /var/log/filebeat
+filebeat_group: filebeat
+filebeat_user: filebeat
+
+filebeat_config:
+  filebeat:
+    prospectors:
+      - paths:
+          - /var/log/messages
+          - /var/log/*.log
+        input_type: log
+  output:
+    elasticsearch:
+      hosts:
+        - localhost:9200
+  logging:
+    level: error
+    to_files: false
+    to_syslog: false

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,0 +1,8 @@
+---
+# handlers file for filebeat
+- name: supervisord restart filebeat
+  supervisorctl:
+    name: 'filebeat'
+    state: restarted
+  when: filebeat_supervisor_enabled
+  ignore_errors: true

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,0 +1,17 @@
+---
+galaxy_info:
+  author: Juwai Limited
+  description:
+  company: Juwai Limited
+  license: MIT / BSD
+  min_ansible_version: 1.9
+  platforms:
+  - name: EL
+    versions:
+    - 6
+  - name: Amazon
+    versions:
+    - 2015.09
+dependencies:
+- role: juwai.supervisor
+  when: filebeat_supervisor_enabled

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: Juwai Limited
   description: Install Filebeat on CentOS servers
   company: Juwai Limited
-  license: MIT / BSD
+  license: MIT
   min_ansible_version: 1.9
   platforms:
   - name: EL

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,7 +1,7 @@
 ---
 galaxy_info:
   author: Juwai Limited
-  description:
+  description: Install Filebeat on CentOS servers
   company: Juwai Limited
   license: MIT / BSD
   min_ansible_version: 1.9
@@ -9,9 +9,10 @@ galaxy_info:
   - name: EL
     versions:
     - 6
-  - name: Amazon
-    versions:
-    - 2015.09
+  # - name: Amazon
+  #   versions:
+  #   - 2015.09
+  galaxy_tags: [amazon, centos6, logstash, beat, filebeat, elk]
 dependencies:
 - role: juwai.supervisor
   when: filebeat_supervisor_enabled

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,0 +1,52 @@
+---
+# tasks file for filebeat
+
+- name: Create group
+  group:
+    name: "{{ filebeat_group }}"
+
+- name: Create user
+  user:
+    name: "{{ filebeat_user }}"
+    group: "{{ filebeat_group }}"
+
+- name: Download rpm
+  get_url:
+    url: "{{ filebeat_rpm_url }}"
+    dest: "/tmp/filebeat-{{ filebeat_version }}.rpm"
+
+- name: Install
+  yum:
+     name: "/tmp/filebeat-{{ filebeat_version }}.rpm"
+     state: present
+
+- name: Create configuration file
+  template:
+    src: "filebeat.yml.j2"
+    dest: "{{ filebeat_config_dir }}/filebeat.yml"
+    mode: 0644
+
+- name: Ensure log directory exists
+  file:
+    path: "{{ filebeat_log_dir }}"
+    state: directory
+    group: "{{ filebeat_group }}"
+    owner: "{{ filebeat_user }}"
+    mode: 0755
+
+- name: Ensure supervisord config directory exists
+  file:
+    path: "{{ supervisord_config_dir }}"
+    state: directory
+    mode: 0755
+  when: filebeat_supervisor_enabled
+
+- name: Install supervisord config script
+  template:
+    src: "supervisor.d_filebeat.conf.j2"
+    dest: "{{ supervisord_config_dir }}/filebeat.conf"
+    owner: root
+    group: root
+    mode: 0644
+  when: filebeat_supervisor_enabled
+  notify: supervisord restart filebeat

--- a/templates/filebeat.yml.j2
+++ b/templates/filebeat.yml.j2
@@ -1,0 +1,2 @@
+# {{ ansible_managed }}
+{{ filebeat_config|to_yaml }}

--- a/templates/supervisor.d_filebeat.conf.j2
+++ b/templates/supervisor.d_filebeat.conf.j2
@@ -1,0 +1,15 @@
+[program:filebeat]
+command=filebeat -e -c {{ filebeat_config_dir }}/filebeat.yml
+directory={{ filebeat_log_dir }}
+user={{ filebeat_user }}
+group={{ filebeat_group }}
+autostart=true
+autorestart=true
+redirect_stdout=true
+redirect_stderr=true
+stdout_logfile={{ filebeat_log_dir }}/stdout.log
+stdout_logfile_maxbytes=20MB
+stdout_logfile_backups=10
+stderr_logfile={{ filebeat_log_dir }}/stderr.log
+stderr_logfile_maxbytes=20MB
+stderr_logfile_backups=10


### PR DESCRIPTION
This role is for installing filebeat. It can optionally add supervisor as a dependency to start it automatically.

To test:
Install juwai.supervisor and juwai.python27 roles. Then run a playbook with this role against a Vagrant box or other CentOS/Amazon Linux instance.

@juwai/platform @agirivera please review
