### PR TITLE
[EN-1416] Add RPC services to Juwai-Mysql box

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,8 +1,12 @@
 ---
 # handlers file for filebeat
+- name: supervisord update filebeat
+  command: supervisorctl update
+  notify: supervisord restart filebeat
+  when: filebeat_supervisor_enabled
+
 - name: supervisord restart filebeat
   supervisorctl:
     name: 'filebeat'
     state: restarted
   when: filebeat_supervisor_enabled
-  ignore_errors: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -49,4 +49,4 @@
     group: root
     mode: 0644
   when: filebeat_supervisor_enabled
-  notify: supervisord restart filebeat
+  notify: supervisord update filebeat


### PR DESCRIPTION
http://jira.juwai.com/browse/EN-1416

Calling update makes sure supervisord has read the config file. If trying to restart the daemon before reading the config file supervisord can shut down. I don't know why this happens. It's probably Ansible related and not supervisord's fault. Also, if config is not read, you can not start the daemon.

@imlazyone @agirivera please review
